### PR TITLE
upgrade bcrypt3 to support new nodeJS versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,14 +7,14 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "bcrypt": "^1.0.2",
+    "bcrypt": "^3.0.6",
     "debug": "^2.6.3",
     "moment": "^2.18.1",
     "uuid": "^3.0.1"
   },
   "peerDependencies": {
     "express": "^4.0.0",
-    "keystone": "4.0.0-beta.5"
+    "keystone": "4.0.0"
   },
   "devDependencies": {
     "body-parser": "^1.17.1",
@@ -27,7 +27,7 @@
     "express": "^4.15.2",
     "husky": "^0.14.3",
     "jest": "^19.0.2",
-    "keystone": "^4.0.0-beta.5",
+    "keystone": "^4.0.0",
     "lint-staged": "^4.0.1",
     "prettier": "^1.5.2",
     "supertest": "^3.0.0",


### PR DESCRIPTION
If you want to install this package on Node 10+ you will get this error:

```
node-pre-gyp ERR! Tried to download(404): https://github.com/kelektiv/node.bcrypt.js/releases/download/v1.0.3/bcrypt_lib-v1.0.3-node-v64-darwin-x64.tar.gz 
node-pre-gyp ERR! Pre-built binaries not found for bcrypt@1.0.3 and node@10.15.1 (node-v64 ABI) (falling back to source compile with node-gyp) 
```

Upgrading bcrypt to 3 makes this package work with old and new Node versions